### PR TITLE
Fixed build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ A simple Neovim plugin to render buffers in a WebKit2Gtk window.
 [dependencies]
 neovim-lib = "0.6"
 horrorshow = "0.6.2"
-webkit2gtk = "0.8"
+webkit2gtk = "0.9"
 pulldown-cmark = { version = "0.6", default-features = false, features = ["simd"] }
 gtk = "^0"
 glib= "^0"

--- a/src/ui/header.rs
+++ b/src/ui/header.rs
@@ -1,3 +1,4 @@
+use crate::gtk::prelude::ComboBoxExtManual;
 use crate::html::theme::Theme;
 use gtk::*;
 


### PR DESCRIPTION
Builds are currently failing due to an error about a missing trait and multiple versions of glib being pulled in. This would address this by bumping the version of webkit2gtk to 0.9 and importing the prelude for ComboBoxExt. I was successfully able to build on Arch Linux using GTK 3.24 and on Debian 10.3.
This should solve issues 16 and 17.